### PR TITLE
gitmodules: Use Relative URL instead of Only SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/ctest"]
 	path = tests/ctest
-	url = git@github.com:darlinghq/ctest.git
+	url = ../ctest.git


### PR DESCRIPTION
For people who don't have ssh set up for GitHub, you will get the error below. Using HTTPS will avoid this error.
```
The authenticity of host 'github.com (...)' can't be established.
RSA key fingerprint is ...
Are you sure you want to continue connecting (yes/no)?
```
