### PR TITLE
Export `_cccurve25519_make_key_pair` symbol

### DIFF
--- a/scripts/exported-symbols.exp
+++ b/scripts/exported-symbols.exp
@@ -98,6 +98,7 @@ _cccmac_one_shot_generate
 #_cccmac_one_shot_verify
 _cccmac_update
 _cccurve25519
+_cccurve25519_make_key_pair
 _ccder_decode_bitstring
 _ccder_decode_constructed_tl
 #_ccder_decode_constructed_tl_strict


### PR DESCRIPTION
When installing MacPorts, it stucks at missing symbol (`_cccurve25519_make_key_pair`) that already exists but is not exported. It fixes that and make MacPorts install and work (it is needed to install BigSur version).

Fixes [darling#429](https://github.com/darlinghq/darling/issues/429)